### PR TITLE
Use portion's public API

### DIFF
--- a/tsmok/emu/emu.py
+++ b/tsmok/emu/emu.py
@@ -640,7 +640,7 @@ class Emu(abc.ABC):
     Raises:
       ValueError in case of error.
     """
-    if not isinstance(interval, portion.interval.Interval):
+    if not isinstance(interval, portion.Interval):
       raise ValueError()
     if interval.empty:
       raise ValueError()


### PR DESCRIPTION
Hello,

It is safer to use `portion`'s public API rather than one of its (private) submodules, since there is no guarantee that these internals won't be changed in the future. 